### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/napalm_skeleton/skeleton.py
+++ b/napalm_skeleton/skeleton.py
@@ -15,7 +15,7 @@
 """
 Napalm driver for Skeleton.
 
-Read napalm.readthedocs.org for more information.
+Read https://napalm.readthedocs.io for more information.
 """
 
 from napalm_base.base import NetworkDriver


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
